### PR TITLE
Handle null message content

### DIFF
--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -9,7 +9,7 @@ def _build_messages_events(messages, completion_id, model):
     for index, message in enumerate(messages):
         currMessage = {
             "id": str(uuid.uuid4()),
-            "content": message.get("content")[:4095],
+            "content": (message.get("content") or "")[:4095],
             "role": message.get("role"),
             "completion_id": completion_id,
             "sequence": index,

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -9,7 +9,7 @@ def _build_messages_events(messages, completion_id, model):
     for index, message in enumerate(messages):
         currMessage = {
             "id": str(uuid.uuid4()),
-            "content": (message.get("content", ""))[:4095],
+            "content": message.get("content", "")[:4095],
             "role": message.get("role"),
             "completion_id": completion_id,
             "sequence": index,

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -9,7 +9,7 @@ def _build_messages_events(messages, completion_id, model):
     for index, message in enumerate(messages):
         currMessage = {
             "id": str(uuid.uuid4()),
-            "content": (message.get("content") or "")[:4095],
+            "content": (message.get("content", ""))[:4095],
             "role": message.get("role"),
             "completion_id": completion_id,
             "sequence": index,


### PR DESCRIPTION
If a captured message is an OpenAI function call, `content` can be null and the existing code will throw