### PR TITLE
Record NR Events and Traces via the New Relic agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["newrelic", "observability", "openai", "gpt", "chatGPT", "GPT-4", "m
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0.0"
-newrelic-telemetry-sdk = "^0.4.0"
+newrelic = "^9.0.0"
 openai = ">=0.8,<0.30"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ pytest = "^7.2.1"
 
 [tool.poetry.group.dev.dependencies]
 langchain = "^0.0.248"
-boto3 = {path = "dependencies/boto3-1.28.21-py3-none-any.whl"}
-botocore = {path = "dependencies/botocore-1.31.21-py3-none-any.whl"}
 chromadb = "^0.4.8"
 tiktoken = "^0.4.0"
 

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -48,7 +48,7 @@ def _get_rate_limit_data(response_headers):
     }
 
 
-def build_completion_events(
+def build_completion_summary(
     response, request, response_headers, response_time, final_message
 ):
     completion_id = newrelic.agent.current_span_id()
@@ -79,7 +79,7 @@ def build_completion_events(
         "api_version": response_headers.get("openai-version"),
         "trace.id": trace_id,
         "transactionId": transaction_id,
-        "response": final_message["content"],
+        "response": (final_message.get("content") or "")[:4095],
     }
 
     completion.update(_get_rate_limit_data(response_headers))
@@ -87,7 +87,7 @@ def build_completion_events(
     return completion
 
 
-def build_completion_error_events(request, error):
+def build_completion_summary_for_error(request, error):
     completion_id = str(uuid.uuid4())
 
     completion = {

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -153,20 +153,3 @@ def build_embedding_error_event(request, error):
     }
 
     return embedding
-
-
-def span_to_event(span: Span):
-    event_dict = {
-        "guid": span["id"],
-        "trace.id": span.get("trace.id"),
-        "parent.id": span.get("parent.id"),
-        "timestamp": span.get("timestamp"),
-        "duration.ms": span.get("duration.ms"),
-    }
-    event_dict.update(**span["attributes"])
-    event_dict.pop("name")
-
-    return dict(
-        table=span["attributes"]["name"],
-        event_dict=event_dict,
-    )

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -7,7 +7,7 @@ import openai
 import newrelic.agent
 
 
-def build_messages_events(messages, model, tags={}):
+def build_messages_events(messages, model, tags={}, start_seq_num=0):
     completion_id = newrelic.agent.current_span_id()
     trace_id = newrelic.agent.current_trace_id()
 
@@ -19,7 +19,7 @@ def build_messages_events(messages, model, tags={}):
             "role": message.get("role"),
             "completion_id": completion_id,
             "trace.id": trace_id,
-            "sequence": index,
+            "sequence": index + start_seq_num,
             "model": model,
             "vendor": "openAI",
             "ingest_source": "PythonSDK",

--- a/src/nr_openai_observability/langchain_callback.py
+++ b/src/nr_openai_observability/langchain_callback.py
@@ -133,7 +133,7 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Run when chain errors."""
         tags = {"error": str(error)}
-        self._finish_segment(kwargs["run_id", tags])
+        self._finish_segment(kwargs["run_id"], tags)
 
     def on_tool_start(
         self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
@@ -166,7 +166,7 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
             "error": str(error),
         }
         newrelic.agent.notice_error()
-        self._finish_segment(kwargs["run_id", tags])
+        self._finish_segment(kwargs["run_id"], tags)
 
     def on_text(self, text: str, **kwargs: Any) -> Any:
         """Run on arbitrary text."""

--- a/src/nr_openai_observability/langchain_callback.py
+++ b/src/nr_openai_observability/langchain_callback.py
@@ -78,15 +78,12 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
 
         llm_output = response.llm_output
         if llm_output:
+            token_usage = response.llm_output.get("token_usage", {})
             tags.update(
                 {
-                    "prompt_tokens": response.llm_output.get(
-                        "token_usage"
-                    ).prompt_tokens,
-                    "completion_tokens": response.llm_output.get(
-                        "token_usage"
-                    ).completion_tokens,
-                    "total_tokens": response.llm_output.get("token_usage").total_tokens,
+                    "prompt_tokens": token_usage.get("prompt_tokens", None),
+                    "completion_tokens": token_usage.get("completion_tokens", None),
+                    "total_tokens": token_usage.get("total_tokens", None),
                 }
             )
         self._finish_segment(kwargs["run_id"])

--- a/src/nr_openai_observability/langchain_callback.py
+++ b/src/nr_openai_observability/langchain_callback.py
@@ -132,7 +132,7 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         """Run when chain errors."""
-        tags = {error: str(error)}
+        tags = {"error": str(error)}
         self._finish_segment(kwargs["run_id", tags])
 
     def on_tool_start(
@@ -163,8 +163,9 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
     ) -> Any:
         """Run when tool errors."""
         tags = {
-            "error": error,
+            "error": str(error),
         }
+        newrelic.agent.notice_error()
         self._finish_segment(kwargs["run_id", tags])
 
     def on_text(self, text: str, **kwargs: Any) -> Any:

--- a/src/nr_openai_observability/langchain_callback.py
+++ b/src/nr_openai_observability/langchain_callback.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Union
-from typing import Any, Dict, List, Union
 
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, BaseMessage, LLMResult
@@ -82,6 +81,13 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
             )
         self._finish_segment(kwargs["run_id"])
 
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> Any:
+        """Run when LLM errors."""
+        tags = {"error": str(error)}
+        self._finish_segment(kwargs["run_id"], tags)
+
     def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> Any:
@@ -91,12 +97,6 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
         }
         trace = newrelic.agent.FunctionTrace(name="AI/LangChain/RunLLM", terminal=False)
         self._start_segment(kwargs["run_id"], trace, tags)
-
-    def on_llm_error(
-        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
-    ) -> Any:
-        """Run when LLM errors."""
-        tags = {"error": str(error)}
 
     def on_chain_start(
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any

--- a/src/nr_openai_observability/monitor.py
+++ b/src/nr_openai_observability/monitor.py
@@ -212,6 +212,7 @@ def handle_start_completion(request):
 
 @handle_errors
 def handle_finish_chat_completion(response, request, response_time):
+    initial_messages = request.get("messages", [])
     final_message = response.choices[0].message
 
     completion = build_completion_summary(
@@ -224,7 +225,10 @@ def handle_finish_chat_completion(response, request, response_time):
     delattr(response, "_nr_response_headers")
 
     response_message = build_messages_events(
-        [final_message], response.model, {"is_final_response": True}
+        [final_message],
+        response.model,
+        {"is_final_response": True},
+        len(initial_messages),
     )[0]
 
     monitor.record_event(response_message, MessageEventName)

--- a/src/nr_openai_observability/monitor.py
+++ b/src/nr_openai_observability/monitor.py
@@ -6,7 +6,6 @@ import time
 import uuid
 from argparse import ArgumentError
 from typing import Any, Dict, Optional
-from typing import Any, Dict, Optional
 
 import openai
 

--- a/src/nr_openai_observability/monitor.py
+++ b/src/nr_openai_observability/monitor.py
@@ -12,8 +12,8 @@ import openai
 import newrelic.agent
 
 from nr_openai_observability.build_events import (
-    build_completion_error_events,
-    build_completion_events,
+    build_completion_summary_for_error,
+    build_completion_summary,
     build_embedding_error_event,
     build_embedding_event,
     build_messages_events,
@@ -174,7 +174,7 @@ def patcher_create_chat_completion(original_fn, *args, **kwargs):
 
             return handle_finish_chat_completion(result, kwargs, time_delta)
     except Exception as ex:
-        build_completion_error_events(ex)
+        build_completion_summary_for_error(ex)
         raise ex
 
 
@@ -196,7 +196,7 @@ async def patcher_create_chat_completion_async(original_fn, *args, **kwargs):
 
             return handle_finish_chat_completion(result, kwargs, None, time_delta)
     except Exception as ex:
-        build_completion_error_events(ex)
+        build_completion_summary_for_error(ex)
         raise ex
 
 
@@ -231,7 +231,7 @@ def handle_start_completion(request):
 def handle_finish_chat_completion(response, request, response_time):
     final_message = response.choices[0].message
 
-    completion = build_completion_events(
+    completion = build_completion_summary(
         response,
         request,
         getattr(response, "_nr_response_headers"),

--- a/src/nr_openai_observability/monitor.py
+++ b/src/nr_openai_observability/monitor.py
@@ -157,7 +157,7 @@ def patcher_create_chat_completion(original_fn, *args, **kwargs):
 
             return handle_finish_chat_completion(result, kwargs, time_delta)
     except Exception as ex:
-        build_completion_summary_for_error(ex)
+        build_completion_summary_for_error(kwargs, ex)
         raise ex
 
 
@@ -179,7 +179,7 @@ async def patcher_create_chat_completion_async(original_fn, *args, **kwargs):
 
             return handle_finish_chat_completion(result, kwargs, time_delta)
     except Exception as ex:
-        build_completion_summary_for_error(ex)
+        build_completion_summary_for_error(kwargs, ex)
         raise ex
 
 


### PR DESCRIPTION
This PR converts this library from using the `telemetry-sdk` to the python `newrelic` agent as a means to push telemetry to New Relic. This comes with a few benefits:
- Events generated in the SDK will now be associated with the same APM app that hosts the AI application
- Spans generated from Langchain or OpenAI can now be viewed in the context of overall APM traces. These calls can therefore also be seen in larger distributed traces
- APM logs can also be correlated to AI/Langchain traces