### PR TITLE
Add async callback handler

### DIFF
--- a/src/nr_openai_observability/async_langchain_callback.py
+++ b/src/nr_openai_observability/async_langchain_callback.py
@@ -1,12 +1,9 @@
-import json
-import logging
 from typing import Any, Dict, List, Union
 
 from langchain.callbacks.base import AsyncCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, BaseMessage, LLMResult
 
-from nr_openai_observability import monitor
-import newrelic.agent
+from nr_openai_observability.langchain_callback import NewRelicCallbackHandler
 
 
 class NewRelicAsyncCallbackHandler(AsyncCallbackHandler):
@@ -17,30 +14,15 @@ class NewRelicAsyncCallbackHandler(AsyncCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """Initialize callback handler."""
-        self.application_name = application_name
-
-        self.new_relic_monitor = monitor.initialization(
-            application_name=application_name,
-            **kwargs,
+        self.sync_handler = NewRelicCallbackHandler(
+            application_name, langchain_callback_metadata, **kwargs
         )
-        self.langchain_callback_metadata = langchain_callback_metadata
-        self.tool_invocation_counter = 0
-        self.trace_stacks = {}
-
-    def get_and_update_tool_invocation_counter(self):
-        self.tool_invocation_counter += 1
-        return self.tool_invocation_counter
 
     async def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> Any:
         """Run when LLM starts running."""
-        tags = {
-            "messages": "\n".join(prompts),
-            "model_name": kwargs.get("invocation_params", {}).get("_type", ""),
-        }
-        trace = newrelic.agent.FunctionTrace(name="AI/LangChain/RunLLM", terminal=False)
-        self._start_segment(kwargs["run_id"], trace, tags)
+        self.sync_handler.on_llm_start(serialized, prompts, **kwargs)
 
     # TODO - Why is there no corresponding end method for this callback? How do we set up spans without this?
     async def on_chat_model_start(
@@ -50,161 +32,61 @@ class NewRelicAsyncCallbackHandler(AsyncCallbackHandler):
         **kwargs: Any,
     ) -> Any:
         """Run when Chat Model starts running."""
-        invocation_params = kwargs.get("invocation_params", {})
-        tags = {
-            "messages": "\n".join([f"{x.type}: {x.content}" for x in messages[0]]),
-            "model": invocation_params.get("model"),
-            "model_name": invocation_params.get("model_name"),
-            "temperature": invocation_params.get("temperature"),
-            "request_timeout": invocation_params.get("request_timeout"),
-            "max_tokens": invocation_params.get("max_tokens"),
-            "stream": invocation_params.get("stream"),
-            "n": invocation_params.get("n"),
-            "temperature": invocation_params.get("temperature"),
-        }
-        trace = newrelic.agent.FunctionTrace(
-            name="AI/LangChain/RunChatModel", terminal=False
-        )
-        self._start_segment(kwargs["run_id"], trace, tags)
+        self.sync_handler.on_chat_model_start(serialized, messages, **kwargs)
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> Any:
         """Run on new LLM token. Only available when streaming is enabled."""
+        self.sync_handler.on_llm_new_token(token, **kwargs)
 
     async def on_llm_end(self, response: LLMResult, **kwargs: Any) -> Any:
         """Run when LLM ends running."""
-
-        tags = {
-            "response": response.generations[0][0].text,
-        }
-
-        llm_output = response.llm_output
-        if llm_output:
-            token_usage = response.llm_output.get("token_usage", {})
-            tags.update(
-                {
-                    "prompt_tokens": token_usage.get("prompt_tokens", None),
-                    "completion_tokens": token_usage.get("completion_tokens", None),
-                    "total_tokens": token_usage.get("total_tokens", None),
-                }
-            )
-        self._finish_segment(kwargs["run_id"])
+        self.sync_handler.on_llm_end(response, **kwargs)
 
     async def on_llm_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         """Run when LLM errors."""
-        tags = {"error": str(error)}
-        self._finish_segment(kwargs["run_id"], tags)
+        self.sync_handler.on_llm_error(error, **kwargs)
 
     async def on_chain_start(
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
     ) -> Any:
-        """Run when chain starts running."""
-
-        key = "chat_history" if inputs.get("chat_history") else "memory"
-        chat_history = (
-            "\n".join([f"{x.type}: {x.content}" for x in inputs.get(key, [])])
-            if inputs.get(key)
-            else ""
-        )
-
-        trace = newrelic.agent.FunctionTrace(
-            name="AI/LangChain/RunChain", terminal=False
-        )
-        logging.warn(json.dumps(inputs))
-        tags = {
-            "input": inputs.get("input") or inputs.get("human_input") or "",
-            "chat_history": chat_history,
-            "run_id": str(kwargs.get("run_id")),
-            "start_tags": str(kwargs.get("tags")),
-            "start_metadata": str(kwargs.get("metadata")),
-        }
-        self._start_segment(kwargs["run_id"], trace, tags)
+        self.sync_handler.on_chain_start(serialized, inputs, **kwargs)
 
     async def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> Any:
         """Run when chain ends running."""
-        tags = {
-            "outputs": outputs.get("output"),
-            "run_id": str(kwargs.get("run_id")),
-            "end_tags": str(kwargs.get("tags")),
-        }
-        self._finish_segment(kwargs["run_id"], tags)
+        self.sync_handler.on_chain_end(outputs, **kwargs)
 
     async def on_chain_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         """Run when chain errors."""
-        tags = {"error": str(error)}
-        self._finish_segment(kwargs["run_id"], tags)
+        self.sync_handler.on_chain_error(error, **kwargs)
 
     async def on_tool_start(
         self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
     ) -> Any:
         """Run when tool starts running."""
-        tool_name = serialized.get("name")
-        trace = newrelic.agent.FunctionTrace(
-            name=f"AI/LangChain/Tool/{tool_name}", terminal=False
-        )
-        tags = {
-            "tool_name": tool_name,
-            "tool_description": serialized.get("description"),
-            "tool_input": input_str,
-        }
-        self._start_segment(kwargs["run_id"], trace, tags)
+        self.sync_handler.on_tool_start(serialized, input_str, **kwargs)
 
     async def on_tool_end(self, output: str, **kwargs: Any) -> Any:
         """Run when tool ends running."""
-        tags = {
-            "tool_output": output,
-            "tool_invocation_counter": self.get_and_update_tool_invocation_counter(),
-        }
-        self._finish_segment(kwargs["run_id"], tags)
+        self.sync_handler.on_tool_end(output, **kwargs)
 
     async def on_tool_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         """Run when tool errors."""
-        tags = {
-            "error": str(error),
-        }
-        newrelic.agent.notice_error()
-        self._finish_segment(kwargs["run_id"], tags)
+        self.sync_handler.on_tool_error(error, **kwargs)
 
     async def on_text(self, text: str, **kwargs: Any) -> Any:
         """Run on arbitrary text."""
+        self.sync_handler.on_text(text, **kwargs)
 
     async def on_agent_action(self, action: AgentAction, **kwargs: Any) -> Any:
         """Run on agent action."""
+        self.sync_handler.on_agent_action(action, **kwargs)
 
     async def on_agent_finish(self, finish: AgentFinish, **kwargs: Any) -> Any:
         """Run on agent end."""
-        # self._finish_segment(kwargs["run_id"])
-
-    def _start_segment(self, run_id, trace, tags={}):
-        trace.__enter__()
-        if self.langchain_callback_metadata:
-            tags = tags or {}
-            tags.update(self.langchain_callback_metadata)
-
-        for key, val in tags.items():
-            trace.add_custom_attribute(key, val)
-
-        stack = self.trace_stacks.get(run_id, [])
-        stack.append(trace)
-
-        self.trace_stacks[run_id] = stack
-
-    def _finish_segment(self, run_id, tags={}):
-        stack = self.trace_stacks.get(run_id, [])
-        if stack != None and len(stack) != 0:
-            trace = stack.pop()
-
-            if len(stack) == 0:
-                self.trace_stacks.pop(run_id, None)
-
-            for key, val in tags.items():
-                trace.add_custom_attribute(key, val)
-
-            trace.__exit__(None, None, None)
-
-            return trace
+        self.sync_handler.on_agent_finish(finish, **kwargs)

--- a/src/nr_openai_observability/openai_monitoring.py
+++ b/src/nr_openai_observability/openai_monitoring.py
@@ -66,7 +66,11 @@ class OpenAIMonitoring:
                     event_dict.update(metadata)
             except Exception as ex:
                 logger.warning(f"Failed to run metadata callback: {ex}")
-        newrelic.agent.record_custom_event(table, event_dict, self.application)
+        transaction = newrelic.agent.current_transaction()
+        if transaction != None:
+            newrelic.agent.record_custom_event(table, event_dict)
+        else:
+            newrelic.agent.record_custom_event(table, event_dict, self.application)
 
 
 monitor = OpenAIMonitoring()


### PR DESCRIPTION
I noticed that Grok is not generating LangChain spans. It seems like this is due to us using a standard callback handler vs an async callback handler. The LangChain docs [here](https://python.langchain.com/docs/modules/callbacks/async_callbacks) seem to say that that setup is allowed but when running Grok locally, it did not seem to capture spans until I switched to the async handler below. 

The async handler just calls out to the sync handler (since there aren't any blocking IO operations anyway)

Also fixed a minor bug where we want to use the agent's normal `record_custom_event` call if this lib's `record_event` is getting called within a transaction. We want to rely on the default `application` populated by the agent rather than relying on the explicit application. We can run into issues if the explicitly passed `application_name` does not match the APM app. In the "Agent bridge" approach, do we even need that `application_name` param anymore?