### PR TITLE
Consistent Span and Completion IDs

### DIFF
--- a/src/nr_openai_observability/patcher.py
+++ b/src/nr_openai_observability/patcher.py
@@ -15,6 +15,7 @@ from nr_openai_observability.build_events import (
     build_embedding_error_event,
     build_embedding_event,
     build_messages_events,
+    get_trace_details,
 )
 from nr_openai_observability.error_handling_decorator import handle_errors
 from nr_openai_observability.openai_monitoring import monitor
@@ -78,19 +79,23 @@ def patcher_create_chat_completion(original_fn, *args, **kwargs):
 
     result, time_delta = None, None
     try:
+        completion_id = str(uuid.uuid4())
         timestamp = time.time()
         with newrelic.agent.FunctionTrace(
             name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
         ):
-            handle_start_completion(kwargs)
+            handle_start_completion(kwargs, completion_id)
             result = original_fn(*args, **kwargs)
             time_delta = time.time() - timestamp
             logger.debug(f"Finished running function: '{original_fn.__qualname__}'.")
 
-            return handle_finish_chat_completion(result, kwargs, time_delta)
+            return handle_finish_chat_completion(
+                result, kwargs, time_delta, completion_id
+            )
     except Exception as ex:
         monitor.record_event(
-            build_completion_summary_for_error(kwargs, ex), consts.SummaryEventName
+            build_completion_summary_for_error(kwargs, ex, completion_id),
+            consts.SummaryEventName,
         )
         raise ex
 
@@ -101,26 +106,30 @@ async def patcher_create_chat_completion_async(original_fn, *args, **kwargs):
     )
     result, time_delta = None, None
     try:
+        completion_id = str(uuid.uuid4())
         timestamp = time.time()
         with newrelic.agent.FunctionTrace(
             name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
         ):
-            handle_start_completion(kwargs)
+            handle_start_completion(kwargs, completion_id)
             result = await original_fn(*args, **kwargs)
 
             time_delta = time.time() - timestamp
             logger.debug(f"Finished running function: '{original_fn.__qualname__}'.")
 
-            return handle_finish_chat_completion(result, kwargs, time_delta)
+            return handle_finish_chat_completion(
+                result, kwargs, time_delta, completion_id
+            )
     except Exception as ex:
         monitor.record_event(
-            build_completion_summary_for_error(kwargs, ex), consts.SummaryEventName
+            build_completion_summary_for_error(kwargs, ex, completion_id),
+            consts.SummaryEventName,
         )
         raise ex
 
 
 @handle_errors
-def handle_start_completion(request):
+def handle_start_completion(request, completion_id):
     transaction = newrelic.agent.current_transaction()
     if transaction and getattr(transaction, "_traceHasHadCompletions", None) == None:
         transaction._traceHasHadCompletions = True
@@ -131,23 +140,23 @@ def handle_start_completion(request):
                 {
                     "human_prompt": human_message["content"],
                     "vendor": "openAI",
-                    "trace.id": transaction.trace_id,
                     "ingest_source": "PythonAgentHybrid",
+                    **get_trace_details(),
                 },
                 consts.TransactionBeginEventName,
             )
 
-    # completion_id = newrelic.agent.current_trace_id()
     message_events = build_messages_events(
         request.get("messages", []),
         request.get("model") or request.get("engine"),
+        completion_id,
     )
     for event in message_events:
         monitor.record_event(event, consts.MessageEventName)
 
 
 @handle_errors
-def handle_finish_chat_completion(response, request, response_time):
+def handle_finish_chat_completion(response, request, response_time, completion_id):
     initial_messages = request.get("messages", [])
     final_message = response.choices[0].message
 
@@ -157,12 +166,14 @@ def handle_finish_chat_completion(response, request, response_time):
         getattr(response, "_nr_response_headers"),
         response_time,
         final_message,
+        completion_id,
     )
     delattr(response, "_nr_response_headers")
 
     response_message = build_messages_events(
         [final_message],
         response.model,
+        completion_id,
         {"is_final_response": True},
         len(initial_messages),
     )[0]

--- a/src/nr_openai_observability/patcher.py
+++ b/src/nr_openai_observability/patcher.py
@@ -82,8 +82,11 @@ def patcher_create_chat_completion(original_fn, *args, **kwargs):
         completion_id = str(uuid.uuid4())
         timestamp = time.time()
         with newrelic.agent.FunctionTrace(
-            name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
-        ):
+            name="AI/OpenAI/Chat/Completions/Create",
+            group="",
+            terminal=True,
+        ) as trace:
+            trace.add_custom_attribute("completion_id", completion_id)
             handle_start_completion(kwargs, completion_id)
             result = original_fn(*args, **kwargs)
             time_delta = time.time() - timestamp
@@ -109,8 +112,11 @@ async def patcher_create_chat_completion_async(original_fn, *args, **kwargs):
         completion_id = str(uuid.uuid4())
         timestamp = time.time()
         with newrelic.agent.FunctionTrace(
-            name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
-        ):
+            name="AI/OpenAI/Chat/Completions/Create",
+            group="",
+            terminal=True,
+        ) as trace:
+            trace.add_custom_attribute("completion_id", completion_id)
             handle_start_completion(kwargs, completion_id)
             result = await original_fn(*args, **kwargs)
 

--- a/src/nr_openai_observability/stream_patcher.py
+++ b/src/nr_openai_observability/stream_patcher.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 
 import newrelic.agent
 
@@ -7,12 +8,15 @@ from nr_openai_observability.build_events import (
     build_completion_summary_for_error,
     build_messages_events,
     build_stream_completion_events,
+    get_trace_details,
 )
 from nr_openai_observability.error_handling_decorator import handle_errors
 from nr_openai_observability.openai_monitoring import monitor
 
 
 def patcher_create_chat_completion_stream(original_fn, *args, **kwargs):
+    completion_id = str(uuid.uuid4())
+
     def wrap_stream_generator(stream_gen):
         role, time_delta, content = None, None, ""
         try:
@@ -20,7 +24,7 @@ def patcher_create_chat_completion_stream(original_fn, *args, **kwargs):
             with newrelic.agent.FunctionTrace(
                 name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
             ):
-                handle_start_completion(kwargs)
+                handle_start_completion(kwargs, completion_id)
                 for chunk in stream_gen:
                     content += chunk.choices[0].delta.get("content", "")
                     if hasattr(chunk.choices[0].delta, "role"):
@@ -29,20 +33,20 @@ def patcher_create_chat_completion_stream(original_fn, *args, **kwargs):
                 time_delta = time.time() - timestamp
         except Exception as ex:
             monitor.record_event(
-                build_completion_summary_for_error(kwargs, ex, True),
+                build_completion_summary_for_error(kwargs, ex, completion_id, True),
                 consts.SummaryEventName,
             )
             raise ex
 
         handle_finish_chat_completion(
-            chunk, kwargs, time_delta, {"role": role, "content": content}
+            chunk, kwargs, time_delta, {"role": role, "content": content}, completion_id
         )
 
     try:
         result = original_fn(*args, **kwargs)
     except Exception as ex:
         monitor.record_event(
-            build_completion_summary_for_error(kwargs, ex, True),
+            build_completion_summary_for_error(kwargs, ex, completion_id, True),
             consts.SummaryEventName,
         )
         raise ex
@@ -53,6 +57,8 @@ def patcher_create_chat_completion_stream(original_fn, *args, **kwargs):
 
 
 async def patcher_create_chat_completion_stream_async(original_fn, *args, **kwargs):
+    completion_id = str(uuid.uuid4())
+
     async def wrap_stream_generator(stream_gen):
         role, time_delta, content = None, None, ""
         try:
@@ -60,7 +66,7 @@ async def patcher_create_chat_completion_stream_async(original_fn, *args, **kwar
             with newrelic.agent.FunctionTrace(
                 name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
             ):
-                handle_start_completion(kwargs)
+                handle_start_completion(kwargs, completion_id)
                 async for chunk in await stream_gen:
                     content += chunk.choices[0].delta.get("content", "")
                     if hasattr(chunk.choices[0].delta, "role"):
@@ -69,20 +75,20 @@ async def patcher_create_chat_completion_stream_async(original_fn, *args, **kwar
                 time_delta = time.time() - timestamp
         except Exception as ex:
             monitor.record_event(
-                build_completion_summary_for_error(kwargs, ex, True),
+                build_completion_summary_for_error(kwargs, ex, completion_id, True),
                 consts.SummaryEventName,
             )
             raise ex
 
         handle_finish_chat_completion(
-            chunk, kwargs, time_delta, {"role": role, "content": content}
+            chunk, kwargs, time_delta, {"role": role, "content": content}, completion_id
         )
 
     try:
         result = original_fn(*args, **kwargs)
     except Exception as ex:
         monitor.record_event(
-            build_completion_summary_for_error(kwargs, ex, True),
+            build_completion_summary_for_error(kwargs, ex, completion_id, True),
             consts.SummaryEventName,
         )
         raise ex
@@ -93,7 +99,7 @@ async def patcher_create_chat_completion_stream_async(original_fn, *args, **kwar
 
 
 @handle_errors
-def handle_start_completion(request):
+def handle_start_completion(request, completion_id):
     transaction = newrelic.agent.current_transaction()
     if transaction and getattr(transaction, "_traceHasHadCompletions", None) == None:
         transaction._traceHasHadCompletions = True
@@ -104,8 +110,8 @@ def handle_start_completion(request):
                 {
                     "human_prompt": human_message["content"],
                     "vendor": "openAI",
-                    "trace.id": transaction.trace_id,
                     "ingest_source": "PythonAgentHybrid",
+                    **get_trace_details(),
                 },
                 consts.TransactionBeginEventName,
             )
@@ -114,13 +120,16 @@ def handle_start_completion(request):
     message_events = build_messages_events(
         request.get("messages", []),
         request.get("model") or request.get("engine"),
+        completion_id,
     )
     for event in message_events:
         monitor.record_event(event, consts.MessageEventName)
 
 
 @handle_errors
-def handle_finish_chat_completion(last_chunk, request, response_time, final_message):
+def handle_finish_chat_completion(
+    last_chunk, request, response_time, final_message, completion_id
+):
     initial_messages = request.get("messages", [])
 
     completion = build_stream_completion_events(
@@ -129,12 +138,14 @@ def handle_finish_chat_completion(last_chunk, request, response_time, final_mess
         getattr(last_chunk, "_nr_response_headers"),
         final_message,
         response_time,
+        completion_id,
     )
     delattr(last_chunk, "_nr_response_headers")
 
     response_message = build_messages_events(
         [final_message],
         last_chunk.model,
+        completion_id,
         {"is_final_response": True},
         len(initial_messages),
     )[0]

--- a/src/nr_openai_observability/stream_patcher.py
+++ b/src/nr_openai_observability/stream_patcher.py
@@ -22,8 +22,11 @@ def patcher_create_chat_completion_stream(original_fn, *args, **kwargs):
         try:
             timestamp = time.time()
             with newrelic.agent.FunctionTrace(
-                name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
-            ):
+                name="AI/OpenAI/Chat/Completions/Create",
+                group="",
+                terminal=True,
+            ) as trace:
+                trace.add_custom_attribute("completion_id", completion_id)
                 handle_start_completion(kwargs, completion_id)
                 for chunk in stream_gen:
                     content += chunk.choices[0].delta.get("content", "")
@@ -64,8 +67,11 @@ async def patcher_create_chat_completion_stream_async(original_fn, *args, **kwar
         try:
             timestamp = time.time()
             with newrelic.agent.FunctionTrace(
-                name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
-            ):
+                name="AI/OpenAI/Chat/Completions/Create",
+                group="",
+                terminal=True,
+            ) as trace:
+                trace.add_custom_attribute("completion_id", completion_id)
                 handle_start_completion(kwargs, completion_id)
                 async for chunk in await stream_gen:
                     content += chunk.choices[0].delta.get("content", "")


### PR DESCRIPTION
The upcoming work to integrate OpenAI into the Python agent will include some changes to attribute names and values. This PR addresses one of those changes. In the agent, each LLM-related event (`LlmChatCompletionMessage`, `LlmChatCompletionSummary`, and `LlmEmbedding`) will have `span_id`, `trace_id`, and `transaction_id` attributes. This PR makes sure those attributes are populated on all events the agent will cover.

We also realized that using the span ID as the `completion_id` field is probably not the best idea. Span IDs may not be the best choice. If the user does not have tracing turned on or the traces are sampled out, will we lose a good id? Instead, this PR switches to generating a UUID and making sure it gets attached to the relevant completion summary and messages. If we need to correlate a completion summary to a span, we can link based on the added `span_id`