### PR TITLE
Making SDK attributes match agent

### DIFF
--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -7,7 +7,6 @@ import uuid
 
 from datetime import datetime
 
-from sympy import comp
 from nr_openai_observability.build_events import compat_fields, get_trace_details
 from nr_openai_observability.monitor import monitor
 from nr_openai_observability.patcher import _patched_call

--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -6,6 +6,8 @@ import time
 import uuid
 
 from datetime import datetime
+
+from sympy import comp
 from nr_openai_observability.build_events import compat_fields, get_trace_details
 from nr_openai_observability.monitor import monitor
 from nr_openai_observability.patcher import _patched_call
@@ -359,7 +361,9 @@ def build_bedrock_events(response, event_dict, time_delta):
                 )
             )
         if max_tokens:
-            summary.update(["max_tokens", "request.max_tokens"], max_tokens)
+            summary.update(
+                compat_fields(["max_tokens", "request.max_tokens"], max_tokens)
+            )
 
         transaction_begin_event = {
             "human_prompt": messages[0]["content"],

--- a/src/nr_openai_observability/build_events.py
+++ b/src/nr_openai_observability/build_events.py
@@ -283,13 +283,9 @@ def build_embedding_event(response, request, response_headers, response_time):
             ["usage.prompt_tokens", "response.usage.prompt_tokens"],
             response.usage.prompt_tokens,
         ),
-        **compat_fields(
-            ["response.api_version", "response.headers.llmVersion"],
-            response_headers.get("openai-version"),
-        ),
         **compat_fields(["api_type", "response.api_type"], response.api_type),
         **compat_fields(
-            ["api_version", "response.api_version"],
+            ["api_version", "response.headers.llmVersion"],
             response_headers.get("openai-version"),
         ),
         **compat_fields(


### PR DESCRIPTION
This PR adds alias names for attributes where the Python agent disagrees with this instrumentation library. After this is merged and has some time to bake in Grok, we should migrate the UI to use the new field names (from the python agent) and then remove the old attribute names.