### PR TITLE
Do not process embedding results

### DIFF
--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -131,8 +131,6 @@ def runTitanEmbedding(bedrock_runtime):
             continue
 
         body = json.dumps({"inputText": line})
-        # Titan modelIds:
-        #  - amazon.titan-text-express-v1
         modelId = "amazon.titan-embed-text-v1"
         accept = "application/json"
         contentType = "application/json"

--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -117,6 +117,38 @@ def runCohere(bedrock_runtime):
     print()
 
 
+@newrelic.agent.background_task()
+@newrelic.agent.function_trace(name="bedrock-embedding")
+def runTitanEmbedding(bedrock_runtime):
+    from pathlib import Path
+
+    # Create an embedding with Amazon Titan
+    data = Path("state_of_the_union.txt").read_text()
+
+    # process each line separated to stay within token limits
+    for line in data.splitlines():
+        if not line:
+            continue
+
+        body = json.dumps({"inputText": line})
+        # Titan modelIds:
+        #  - amazon.titan-text-express-v1
+        modelId = "amazon.titan-embed-text-v1"
+        accept = "application/json"
+        contentType = "application/json"
+
+        print(f'Test Embedding with AWS Titan model {modelId}')
+        response = bedrock_runtime.invoke_model(
+            body=body, modelId=modelId, accept=accept, contentType=contentType
+        )
+        response_body = json.loads(response.get("body").read())
+
+        print(f"input length {len(line)} generated {len(response_body.get('embedding'))} embeddings")
+        break # only sending the first line for testing
+
+    print()
+
+
 if __name__ == "__main__":
     app_name = os.getenv('NEW_RELIC_APP_NAME')
     if not app_name:
@@ -145,6 +177,7 @@ if __name__ == "__main__":
     runAnthropic(bedrock_runtime)
     runAi21(bedrock_runtime)
     runCohere(bedrock_runtime)
+    runTitanEmbedding(bedrock_runtime)
 
     # Allow the New Relic agent to send final messages as part of shutdown
     # The agent by default can send data up to a minute later

--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -203,10 +203,6 @@ def handle_bedrock_embedding(result, contents, time_delta, **kwargs):
         "vendor": "Bedrock",
         "ingest_source": "PythonSDK",
         **compat_fields(["response_time", "duration"], int(time_delta * 1000)),
-        **compat_fields(
-            ["usage.total_tokens", "response.usage.total_tokens"],
-            len(response_body.get("embedding")),
-        ),
         **get_trace_details(),
     }
 

--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -160,6 +160,10 @@ def handle_bedrock_create_completion(response, contents, time_delta, **kwargs):
             body = json.loads(event_dict["body"])
             event_dict["body"] = body
 
+        if "embedding" in response_body:
+            # currently not instrumenting embedding calls. Just exit early.
+            return
+
         (summary, messages, transaction_begin_event) = build_bedrock_events(
             response, event_dict, time_delta
         )


### PR DESCRIPTION
In AWS Bedrock, the Titan embedding uses the same method call as all of the calls to the LLMs. For now, if the result is an embedding, then just skip processing the data. Eventually, we'll likely come back to the embedding calls and will process them separately. For now, ensure that anyone invoking an embedding does not see any errors in their logs.