### PR TITLE
fix: Add missing completion ID to spans

### DIFF
--- a/src/nr_openai_observability/patcher.py
+++ b/src/nr_openai_observability/patcher.py
@@ -87,7 +87,7 @@ def patcher_create_chat_completion(original_fn, *args, **kwargs):
             terminal=True,
         ) as trace:
             trace.add_custom_attribute("completion_id", completion_id)
-            monitor.record_library('openai', 'OpenAI')
+            monitor.record_library("openai", "OpenAI")
             handle_start_completion(kwargs, completion_id)
             result = original_fn(*args, **kwargs)
             time_delta = time.time() - timestamp
@@ -114,8 +114,9 @@ async def patcher_create_chat_completion_async(original_fn, *args, **kwargs):
         timestamp = time.time()
         with newrelic.agent.FunctionTrace(
             name="AI/OpenAI/Chat/Completions/Create", group="", terminal=True
-        ):
-            monitor.record_library('openai', 'OpenAI')
+        ) as trace:
+            trace.add_custom_attribute("completion_id", completion_id)
+            monitor.record_library("openai", "OpenAI")
             handle_start_completion(kwargs, completion_id)
             result = await original_fn(*args, **kwargs)
 
@@ -463,6 +464,7 @@ def perform_patch():
         pass
 
     from nr_openai_observability.bedrock import perform_patch_bedrock
+
     perform_patch_bedrock()
 
     if "langchain" in sys.modules:


### PR DESCRIPTION
This PR fixes an issue with the OpenAI instrumentation where some chat completion spans were not getting tagged with a proper completion ID. We decided to tag the spans with a completion ID rather than just tagging the completions with a span ID because it was harder to make sure the right span ID is always attached to completions (in async cases for example)

This PR also refactors the bedrock instrumentation to also attach this `completion_id` to spans