### PR TITLE
Calculate the full input, output and total token counts for Bedrock Anthropic

### DIFF
--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -26,7 +26,8 @@ def runTitan(bedrock_runtime):
     body = json.dumps({"inputText": prompt_data})
     # Titan modelIds:
     #  - amazon.titan-text-express-v1
-    modelId = "amazon.titan-text-express-v1"
+    #  - amazon.titan-text-lite-v1
+    modelId = "amazon.titan-text-express-v1" 
     accept = "application/json"
     contentType = "application/json"
 

--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -304,17 +304,12 @@ def build_bedrock_events(response, event_dict, completion_id, time_delta):
                     )
                 )
         elif "claude" in model:
-            from anthropic import _tokenizers
-
-            tokenizer = _tokenizers.sync_get_tokenizer()
-            encoded = tokenizer.encode(event_dict["completion"])
-            tokens += len(encoded)
             messages.append(
                 build_bedrock_result_message(
                     completion_id=completion_id,
                     message_id=message_id,
                     content=event_dict["completion"],
-                    tokens=len(encoded),
+                    tokens=response_tokens,
                     role="assistant",
                     sequence=len(messages),
                     stop_reason=event_dict["stop_reason"],
@@ -489,6 +484,9 @@ def get_bedrock_info(event_dict):
             tokenizer = _tokenizers.sync_get_tokenizer()
             encoded = tokenizer.encode(input_message)
             input_tokens = len(encoded)
+
+            encoded = tokenizer.encode(event_dict["completion"])
+            response_tokens = len(encoded)
         if "ai21.j2" in model:
             input_message = event_dict["prompt.text"]
             input_tokens = len(event_dict["prompt.tokens"])


### PR DESCRIPTION
The token counts were off for Bedrock Anthropic. Only the output token count was set properly. The input token count was missed and thus the total token count was off.