### PR TITLE
feat: Update ai ids to request_id, update feedback event name

### DIFF
--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -235,6 +235,13 @@ def build_bedrock_events(response, event_dict, completion_id, time_delta):
         temperature,
         max_tokens,
     ) = get_bedrock_info(event_dict)
+
+    request_id = None
+    if None != response.get("ResponseMetadata") and None != response.get(
+        "ResponseMetadata"
+    ).get("RequestId"):
+        request_id = response.get("ResponseMetadata").get("RequestId")
+
     summary = {}
     messages = []
     model = "bedrock-unknown"
@@ -357,7 +364,7 @@ def build_bedrock_events(response, event_dict, completion_id, time_delta):
 
         if len(messages) > 0:
             messages[-1]["is_final_response"] = True
-            ai_message_id = create_ai_message_id(messages[-1].get("id"))
+            ai_message_id = create_ai_message_id(messages[-1].get("id"), request_id)
             set_ai_message_ids([ai_message_id])
 
         summary = {

--- a/src/nr_openai_observability/call_vars.py
+++ b/src/nr_openai_observability/call_vars.py
@@ -27,9 +27,9 @@ def set_conversation_id(id):
 def get_conversation_id():
     return conversation_id.get(None)
 
-def create_ai_message_id(message_id, response_id=None):
+def create_ai_message_id(message_id,  request_id=None):
     return {
         "conversation_id": get_conversation_id(),
-        "response_id": response_id,
+        "request_id": request_id,
         "message_id": message_id,
     }

--- a/src/nr_openai_observability/consts.py
+++ b/src/nr_openai_observability/consts.py
@@ -1,7 +1,7 @@
 EventName = "LlmCompletion"
 MessageEventName = "LlmChatCompletionMessage"
 SummaryEventName = "LlmChatCompletionSummary"
-FeedbackEventName = "LlmChatFeedback"
+FeedbackEventName = "LlmFeedbackMessage"
 EmbeddingEventName = "LlmEmbedding"
 VectorSearchEventName = "LlmVectorSearch"
 VectorSearchResultsEventName = "LlmVectorSearchResult"

--- a/src/nr_openai_observability/patcher.py
+++ b/src/nr_openai_observability/patcher.py
@@ -171,11 +171,12 @@ def handle_start_completion(request, completion_id):
 def handle_finish_chat_completion(response, request, response_time, completion_id):
     initial_messages = request.get("messages", [])
     final_message = response.choices[0].message
+    response_headers = getattr(response, "_nr_response_headers")
 
     completion = build_completion_summary(
         response,
         request,
-        getattr(response, "_nr_response_headers"),
+        response_headers,
         response_time,
         final_message,
         completion_id,
@@ -196,7 +197,7 @@ def handle_finish_chat_completion(response, request, response_time, completion_i
     ai_message_ids = get_ai_message_ids(response.get("id"))
 
     ai_message_ids.append(
-        create_ai_message_id(response_message.get("id"), response.get("id"))
+        create_ai_message_id(response_message.get("id"), response_headers.get("x-request-id", ""))
     )
 
     set_ai_message_ids(ai_message_ids, response.get("id"))

--- a/src/nr_openai_observability/stream_patcher.py
+++ b/src/nr_openai_observability/stream_patcher.py
@@ -143,11 +143,12 @@ def handle_finish_chat_completion(
     last_chunk, request, response_time, final_message, completion_id
 ):
     initial_messages = request.get("messages", [])
+    response_headers = getattr(last_chunk, "_nr_response_headers")
 
     completion = build_stream_completion_events(
         last_chunk,
         request,
-        getattr(last_chunk, "_nr_response_headers"),
+        response_headers,
         final_message,
         response_time,
         completion_id,
@@ -168,7 +169,7 @@ def handle_finish_chat_completion(
     ai_message_ids = get_ai_message_ids(response.get("id"))
 
     ai_message_ids.append(
-        create_ai_message_id(response_message.get("id"), response.get("id"))
+        create_ai_message_id(response_message.get("id"), response_headers.get("x-request-id", ""))
     )
 
     set_ai_message_ids(ai_message_ids, response.get("id"))


### PR DESCRIPTION
This updates the ai message IDs to take the request ID, not response ID, for the objects per the CDD.

It also updates the feedback event name to match the CDD