### PR TITLE
Adding a basic `setup.cfg` to support pip installs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = nr-openai-observability
+version = attr: my_package.VERSION
+author = New Relic
+description = An extension for New Relic APM to support AI libraries
+long_description = file: README.md, LICENSE
+license = Apache-2.0 license
+keywords = newrelic, observability, openai, gpt, chatGPT, GPT-4, monitor, generative, ai
+
+[options]
+zip_safe = False
+include_package_data = True
+python_requires = >=3.8.1
+install_requires =
+package_dir=
+    =src
+packages=find:
+
+[options.package_data]
+* = *.txt, *.rst
+hello = *.msg
+
+[options.entry_points]
+console_scripts =
+    executable-name = my_package.module:function
+
+[options.extras_require]
+newrelic
+openai = openai>=0.8,<0.30
+tiktoken = tiktoken^0.5.1
+
+[options.packages.find]
+where=src


### PR DESCRIPTION
Adding a bare bones setup.cfg to quickly support installing via pip with more recent versions of setuptools.