### PR TITLE
Clean up RunChain events + spans

### DIFF
--- a/src/nr_openai_observability/langchain_callback.py
+++ b/src/nr_openai_observability/langchain_callback.py
@@ -130,7 +130,10 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
             name="AI/LangChain/RunChain", terminal=False
         )
         tags = {
-            "input": inputs.get("input") or inputs.get("human_input") or "",
+            "input": inputs.get("input")
+            or inputs.get("human_input")
+            or inputs.get("content")
+            or "",
             "chat_history": chat_history,
             "run_id": str(kwargs.get("run_id")),
             "start_tags": str(kwargs.get("tags")),
@@ -141,7 +144,7 @@ class NewRelicCallbackHandler(BaseCallbackHandler):
     def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> Any:
         """Run when chain ends running."""
         tags = {
-            "outputs": outputs.get("output"),
+            "output": outputs.get("text", None) or outputs.get("output", None),
             "run_id": str(kwargs.get("run_id")),
             "end_tags": str(kwargs.get("tags")),
         }


### PR DESCRIPTION
Quick PR to clean up the RunChain callback. I noticed that a properties we're keying off have changed names over LangChain versions. I added in a couple property names to make sure Grok and our sample app (at least) are seeing data.