### PR TITLE
Capture content length

### DIFF
--- a/src/nr_openai_observability/bedrock.py
+++ b/src/nr_openai_observability/bedrock.py
@@ -276,7 +276,7 @@ def build_bedrock_events(response, event_dict, completion_id, time_delta):
             build_bedrock_result_message(
                 completion_id=completion_id,
                 message_id=str(uuid.uuid4()),
-                content=input_message[:4095],
+                content=input_message,
                 tokens=input_tokens,
                 role="user",
                 sequence=len(messages),
@@ -405,7 +405,6 @@ def build_bedrock_events(response, event_dict, completion_id, time_delta):
             **compat_fields(
                 ["number_of_messages", "response.number_of_messages"], len(messages)
             ),
-            "response": messages[-1]["content"][:4095],
             **get_trace_details(),
         }
 
@@ -464,6 +463,7 @@ def build_bedrock_result_message(
     message = {
         "id": message_id,
         "content": content[:4095],
+        "content_length": len(content),
         "conversation_id": get_conversation_id(),
         "role": role,
         "completion_id": completion_id,


### PR DESCRIPTION
This PR adds a `content_length` field to `LlmChatCompletionMessage` events so that when message content truncates, we know how much got cut off.

This PR also removes the `response` field from `LlmChatCompletionSummary`. This change is riskier but important. The agents will not be storing the final message content in that `response` field. Our UIs have already been migrated to get content from messages. There is _some_ risk that an LP customer has made a dashboard using that field but I think it's a pretty low chance. If you think this change should be a separate PR, LMK. I think it should go in soon to reduce the risk of more customers using it