### PR TITLE
Update tiktoken version to >=0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
 python = ">=3.8.1,<4.0.0"
 newrelic = { git = "https://github.com/newrelic/newrelic-python-agent.git", rev = "c7d3fbb372ed6327694c77480e3fa44fdc658d0e" }
 openai = ">=0.8,<2.0"
-tiktoken = "^0.5.1"
+tiktoken = ">=0.5.1, <=0.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.1"


### PR DESCRIPTION
This pull request updates the `tiktoken` dependency version range to accommodate the new version 0.7.0, which introduces support for the `gpt4o` model. This change ensures compatibility with applications that require the latest features and improvements from `tiktoken`.

Current dependency version: `tiktoken = "^0.5.1"`
Updated dependency version: `tiktoken = ">=0.5.1, <=0.7.0"`

### Reason for Change

My application, which uses [nr-openai-observability](https://github.com/newrelic/nr-openai-observability) package, requires the tiktoken version 0.7.0 to leverage the new gpt4o model support. By updating the version range, this PR resolves the dependency conflict in my application, allowing my application to function correctly with the latest tiktoken version.